### PR TITLE
Add z-index to nav-bar

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -1,7 +1,7 @@
 <template>
 
 
-  <v-toolbar :style="bar_colour" dark>
+  <v-toolbar :style="bar_colour" style="z-index: 5" dark>
 
 
     <v-toolbar-title>{{title}}</v-toolbar-title>


### PR DESCRIPTION
Hello,
I noticed that on mobile the hamburger menu in the toolbar gets hidden/covered by parts of the content.

<img src="https://user-images.githubusercontent.com/6861911/98452259-ebf78e00-214d-11eb-9e1b-04edf6178c84.png" width="350" />

I believe this is due to `transform: translateY(0px)` setting a new stacking context (https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context). Since the transform is used to fix some other bug (https://github.com/vuetifyjs/vuetify/issues/7742), it can't be removed. Adding a z-index however should be fix the issue as well.

<img src="https://user-images.githubusercontent.com/6861911/98452506-2d893880-2150-11eb-96ee-cba7dd6760aa.png" width="350" />

Cheers
